### PR TITLE
Release v0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silexlabs/grapesjs-data-source",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@silexlabs/grapesjs-data-source",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.13.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.13.8",
-        "@silexlabs/expression-input": "0.4.4",
+        "@silexlabs/expression-input": "0.4.5",
         "dedent-js": "^1.0.1"
       },
       "devDependencies": {
@@ -2839,9 +2839,9 @@
       }
     },
     "node_modules/@silexlabs/expression-input": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@silexlabs/expression-input/-/expression-input-0.4.4.tgz",
-      "integrity": "sha512-lVmYPjbbIdjT9mPLfCSwnFzZHhAgx18cnUu2toIf2+gbeCw0a6eW250ERVsv/xYXagU+NuB21WNo81f82fMEOQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@silexlabs/expression-input/-/expression-input-0.4.5.tgz",
+      "integrity": "sha512-MXP84sZ3msydPK70hvs4Xfw2GpKx7ySu7pgC+7zjQf6I8b5GQfWqvaVosxFQ4KRxZzPM2jpR9XHOsvd2WHsiuA==",
       "license": "AGPL-3.0",
       "dependencies": {
         "lit": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silexlabs/grapesjs-data-source",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Grapesjs Data Source",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@apollo/client": "^3.13.8",
-    "@silexlabs/expression-input": "0.4.4",
+    "@silexlabs/expression-input": "0.4.5",
     "dedent-js": "^1.0.1"
   }
 }


### PR DESCRIPTION
Release v0.2.2 — bump commit already published on npm and referenced by silex-meta v3.7.3.

This PR aligns `main` with the released state.